### PR TITLE
Added Invalid CSharp characters

### DIFF
--- a/LateboundConstantGenerator/MetadataProxy.cs
+++ b/LateboundConstantGenerator/MetadataProxy.cs
@@ -48,7 +48,9 @@ namespace Rappen.XTB.LCG
                 .Replace("-", "_")
                 .Replace("+", "_")
                 .Replace("/", "_")
-                .Replace("\\", "_");
+                .Replace("\\", "_")
+                .Replace("[", "_")
+                .Replace("]", "_");
         }
     }
 }


### PR DESCRIPTION
Adding "[" and "]" to the list of invalid characters to replace when generating enum cSharpNames